### PR TITLE
Adding a copy step to create appSettings.Development.json if it doesn't exist

### DIFF
--- a/examples/CoffeeShop/CoffeeShop.csproj
+++ b/examples/CoffeeShop/CoffeeShop.csproj
@@ -9,15 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\appSettings.Development.json" Link="appSettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\appSettings.json" Link="appSettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\typechat.app\typechat.app.csproj" />
     <ProjectReference Include="..\..\src\typechat.sk\typechat.sk.csproj" />
     <ProjectReference Include="..\..\src\typechat\typechat.csproj" />

--- a/examples/CoffeeShop2/CoffeeShop2.csproj
+++ b/examples/CoffeeShop2/CoffeeShop2.csproj
@@ -9,15 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\appSettings.Development.json" Link="appSettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\appSettings.json" Link="appSettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\typechat.app\typechat.app.csproj" />
     <ProjectReference Include="..\..\src\typechat.sk\typechat.sk.csproj" />
     <ProjectReference Include="..\..\src\typechat\typechat.csproj" />

--- a/examples/Directory.Build.targets
+++ b/examples/Directory.Build.targets
@@ -1,0 +1,12 @@
+<Project>
+  <Target Name="BeforeBuild">
+    <Copy SourceFiles="..\appSettings.json" DestinationFiles="..\appSettings.Development.json"
+          Condition="!Exists('..\appSettings.Development.json')"/>
+  </Target>
+
+  <ItemGroup>
+    <Content Include="..\appSettings*.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/examples/Sentiment/Sentiment.csproj
+++ b/examples/Sentiment/Sentiment.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,24 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="..\appSettings.Development.json" Link="appSettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\appSettings.json" Link="appSettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\typechat.app\typechat.app.csproj" />
     <ProjectReference Include="..\..\src\typechat.sk\typechat.sk.csproj" />
     <ProjectReference Include="..\..\src\typechat\typechat.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="appSettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Update="input.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/examples/math/math.csproj
+++ b/examples/math/math.csproj
@@ -6,17 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>annotations</Nullable>
     <RootNamespace>Math</RootNamespace>
-    
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="..\appSettings.Development.json" Link="appSettings.Development.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="..\appSettings.json" Link="appSettings.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\typechat.app\typechat.app.csproj" />

--- a/typechat.sln
+++ b/typechat.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "examples", "examples", "{17
 	ProjectSection(SolutionItems) = preProject
 		examples\appSettings.Development.json = examples\appSettings.Development.json
 		examples\appSettings.json = examples\appSettings.json
+		examples\Directory.Build.targets = examples\Directory.Build.targets
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sentiment", "examples\Sentiment\sentiment.csproj", "{68E9AF34-7982-4BA4-864D-D24DF937A6A2}"
@@ -32,7 +33,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "coffeeShop2", "examples\Cof
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "typechat.program", "src\typechat.program\typechat.program.csproj", "{C223E3DB-9B2E-4839-A56E-838030300938}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "math", "examples\math\math.csproj", "{131566E6-2B78-486C-AFF5-7202A437E79F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "math", "examples\math\math.csproj", "{131566E6-2B78-486C-AFF5-7202A437E79F}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
MSBuild creates appSettings.Development.json as a copy of appSettings.json, if it doesn't exist. This prevents csproj load and build failures upon initial repo clone.

Also auto-loading both appSetting json files into all examples projects through Directory.Build.targets.

Fixes #31