### PR TITLE
Fixed tests to run if OpenAI config is not available

### DIFF
--- a/src/typechat.app/Config.cs
+++ b/src/typechat.app/Config.cs
@@ -13,10 +13,14 @@ public class Config
     public static T LoadConfig<T>(string configFile, string configOverloadFile, string sectionName = default)
         where T : new()
     {
-        var config = new ConfigurationBuilder()
-                    .AddJsonFile(configFile, false, true)
-                    .AddJsonFile(configOverloadFile, false, true)
-                    .Build();
+        var configBuilder = new ConfigurationBuilder()
+                    .AddJsonFile(configFile, false, true);
+
+        if (File.Exists(configOverloadFile))
+        {
+            configBuilder.AddJsonFile(configOverloadFile, false, true);
+        }
+        var config = configBuilder.Build();
         var configSection = config.GetSection(sectionName);
         if (configSection == null)
         {

--- a/tests/TestTypeTranslate.cs
+++ b/tests/TestTypeTranslate.cs
@@ -14,7 +14,7 @@ public class TestTypeTranslate : TypeChatTest, IClassFixture<Config>
     [Fact]
     public async Task TestEndToEnd()
     {
-        if (!_config.HasOpenAI)
+        if (!CanRunEndToEndTest(_config))
         {
             Trace.WriteLine("No Open AI. Skipping");
             return;

--- a/tests/TypeChatTest.cs
+++ b/tests/TypeChatTest.cs
@@ -40,5 +40,11 @@ public class TypeChatTest
         }
     }
 
+    public bool CanRunEndToEndTest(Config config)
+    {
+        return (config.HasOpenAI &&
+                !string.IsNullOrEmpty(config.OpenAI.ApiKey) &&
+                config.OpenAI.ApiKey != "?");
+    }
 }
 


### PR DESCRIPTION
- End to end tests will log and exit run if no keys 
- Test code: check for config file before creating config builder