### PR TITLE
Update dotnet-build-test.yml

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -25,11 +25,13 @@ jobs:
         fail-fast: false
         matrix:
           include:
-          - { dotnet: '6.0-jammy', os: 'ubuntu', configuration: Debug }
+#          - { dotnet: '6.0-jammy', os: 'ubuntu', configuration: Debug }
+          - { dotnet: '7.0-jammy', os: 'ubuntu', configuration: Debug }
           - { dotnet: '7.0-jammy', os: 'ubuntu', configuration: Release }
           - { dotnet: '8.0-preview-jammy', os: 'ubuntu', configuration: Release }
-          - { dotnet: '6.0', os: 'windows', configuration: Release }
+#          - { dotnet: '6.0', os: 'windows', configuration: Release }
           - { dotnet: '7.0', os: 'windows', configuration: Debug }
+          - { dotnet: '7.0', os: 'windows', configuration: Release }
           - { dotnet: '8.0-preview', os: 'windows', configuration: Release }
           
     runs-on: ubuntu-latest


### PR DESCRIPTION
Disable 6.0 builds, add a Debug and Release for 7.0 (linux, windows).