### PR TITLE
Fixes Issue 162

### DIFF
--- a/src/typechat.program/CSharp/CSharpProgramTranspiler.cs
+++ b/src/typechat.program/CSharp/CSharpProgramTranspiler.cs
@@ -313,7 +313,7 @@ public class CSharpProgramTranspiler
                             break;
 
                         case ArrayExpr array:
-                            AddJsonProperty(writer, jsonObj, property.Key, Compile(array));
+                            AddJsonProperty(writer, jsonObj, property.Key, Compile(array), typeof(Array));
                             break;
 
                         case ObjectExpr obj:
@@ -341,7 +341,7 @@ public class CSharpProgramTranspiler
             if (valueType != null)
             {
                 if (valueType.IsString() ||
-                    valueType.IsValueType)
+                    valueType.IsPrimitive)
                 {
                     writer.Append(value);
                 }
@@ -350,8 +350,7 @@ public class CSharpProgramTranspiler
                     //
                     // Direct cast not available. Serialize to JsonNode first
                     //
-                    writer.Cast(nameof(JsonNode));
-                    writer.StaticCall("JsonSerializer.Serialize", value, CSharpLang.TypeOf(valueType.Name));
+                    writer.StaticCall("JsonSerializer.SerializeToNode", value, CSharpLang.TypeOf(valueType.Name));
                 }
             }
             else

--- a/src/typechat.program/JsonNodeEx.cs
+++ b/src/typechat.program/JsonNodeEx.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.TypeChat;
+
+internal static class JsonNodeEx
+{
+    public static bool IsConvertibleToJsonNode(this Type type)
+    {
+        return (type.IsPrimitive || type.IsString());
+    }
+
+    public static JsonNode ToJsonNode(dynamic obj)
+    {
+        if (obj == null)
+        {
+            return obj;
+        }
+        if (obj is dynamic[] darray)
+        {
+            JsonArray jsonArray = new JsonArray();
+            for (int i = 0; i < darray.Length; ++i)
+            {
+                dynamic value = darray[i];
+                jsonArray.Add(ToJsonNode(value));
+            }
+            return jsonArray;
+        }
+        else if (obj is Array array)
+        {
+            JsonArray jsonArray = new JsonArray();
+            for (int i = 0; i < array.Length; ++i)
+            {
+                dynamic value = array.GetValue(i);
+                jsonArray.Add(ToJsonNode(value));
+            }
+            return jsonArray;
+        }
+        return obj;
+    }
+
+}

--- a/src/typechat.program/ProgramCompiler.cs
+++ b/src/typechat.program/ProgramCompiler.cs
@@ -286,7 +286,7 @@ public class ProgramCompiler
                         break;
 
                     case ArrayExpr arrayExpr:
-                        addJsonPropertyExpr = AddJsonProperty(jsonObjExpr, property.Key, Compile(arrayExpr));
+                        addJsonPropertyExpr = AddJsonProperty(jsonObjExpr, property.Key, CastToJsonNode(Compile(arrayExpr), typeof(Array)));
                         block.Add(addJsonPropertyExpr);
                         break;
 
@@ -343,7 +343,7 @@ public class ProgramCompiler
 
     UnaryExpression CastToJsonNode(LinqExpression srcExpr, Type srcType)
     {
-        if (!(srcType.IsValueType || srcType.IsString()))
+        if (!(srcType.IsPrimitive || srcType.IsString()))
         {
             //
             // Direct cast not available. Serialize to JsonNode
@@ -432,9 +432,9 @@ public class ProgramCompiler
             return JsonSerializer.Deserialize(obj, type);
         }
 
-        public static JsonObject Serialize(object obj)
+        public static JsonNode Serialize(object obj)
         {
-            return (JsonObject)JsonSerializer.Serialize(obj);
+            return JsonSerializer.SerializeToNode(obj);
         }
 
         public static JsonObject AddNode(JsonObject obj, string name, JsonNode node)

--- a/src/typechat.program/ProgramInterpreter.cs
+++ b/src/typechat.program/ProgramInterpreter.cs
@@ -252,32 +252,5 @@ public class ProgramInterpreter
     /// </summary>
     /// <param name="obj">obj to convert</param>
     /// <returns></returns>
-    public static JsonNode ToJsonNode(dynamic obj)
-    {
-        if (obj == null)
-        {
-            return obj;
-        }
-        if (obj is dynamic[] darray)
-        {
-            JsonArray jsonArray = new JsonArray();
-            for (int i = 0; i < darray.Length; ++i)
-            {
-                dynamic value = darray[i];
-                jsonArray.Add(ToJsonNode(value));
-            }
-            return jsonArray;
-        }
-        else if (obj is Array array)
-        {
-            JsonArray jsonArray = new JsonArray();
-            for (int i = 0; i < array.Length; ++i)
-            {
-                dynamic value = array.GetValue(i);
-                jsonArray.Add(ToJsonNode(value));
-            }
-            return jsonArray;
-        }
-        return obj;
-    }
+    public static JsonNode ToJsonNode(dynamic obj) => JsonNodeEx.ToJsonNode(obj);
 }

--- a/src/typechat.program/ProgramInterpreter.cs
+++ b/src/typechat.program/ProgramInterpreter.cs
@@ -245,7 +245,7 @@ public class ProgramInterpreter
     /// <summary>
     /// obj can be one of:
     /// - dynamic[]  (returned by ArrayExpr)
-    /// - dynamic (returned by valueExpr and ResulRef)
+    /// - dynamic (returned by valueExpr and ResultReference)
     /// - JsonObject (returned by ObjectExpr)
     ///
     /// dynamic[] must be converted to a JsonArray


### PR DESCRIPTION
Issue 162 
- Fixed in ProgramInterpreter and ProgramCompiler
- When JsonObjects are being constructed from ObjectExpr, the arrays returned by ArrayExpr were not being correctly converted to JsonArray. This lead to a RuntimeBinder exception