### PR TITLE
chore(dependabot): group routine and security update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,7 @@ updates:
       nuget-security:
         applies-to: security-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -39,9 +40,14 @@ updates:
       day: "monday"
     labels:
       - "dependencies"
+    # Same policy as nuget above: group minor/patch only so major-version
+    # action bumps (e.g. actions/checkout v4 -> v5) get individual PRs
+    # and can be reviewed for breaking-change notes.
     groups:
       github-actions:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,30 @@ updates:
       - dependency-name: "Microsoft.Extensions.*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "Microsoft.Bcl.*"
-        update-types: ["version-update:semver-major"]      
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
+    # Group routine minor/patch bumps to keep PR volume manageable.
+    # Security updates are grouped separately so they can be prioritised,
+    # and major-version bumps fall through to one-PR-per-package.
+    groups:
+      nuget-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      nuget-security:
+        applies-to: security-updates
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns: ["*"]
+      github-actions-security:
+        applies-to: security-updates
+        patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Dependabot configuration for microsoft/typechat.net.
+#
+# Per ecosystem: routine minor/patch updates are grouped into a single
+# weekly PR; security updates ship as their own grouped PR; major-version
+# bumps fall through ungrouped (one PR per package) for breaking-change
+# review.
+#
+# Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:


### PR DESCRIPTION
## Change

Add Dependabot grouping rules to the existing `nuget` ecosystem (and add coverage for `github-actions`, which wasn't previously declared) so that multiple updates in a given run collapse into a single PR. Routine version updates and security-advisory-triggered updates are grouped **separately** (via `applies-to: security-updates`) so security PRs can be prioritised on their own.

Major-version bumps continue to open one PR per package so reviewers can evaluate them individually, and the existing `System.*` / `Microsoft.Extensions.*` / `Microsoft.Bcl.*` major-version ignore rules remain in effect.

## Status

This repo currently has **0 open Dependabot alerts**, so this change is preventive — it ensures that when alerts do accumulate, they arrive as a single triagable PR rather than many.