### PR TITLE
ci(dependabot): switch to security-only mode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,19 @@
 # but NOT routine weekly version-update PRs. Setting
 # open-pull-requests-limit: 0 on each ecosystem block disables version
 # updates while keeping the ecosystem registered so security-update PRs
-# can still be opened automatically when an alert fires.
+# can still be opened automatically when an alert fires. (Security
+# updates have a separate, fixed limit of 10 that is unaffected by
+# open-pull-requests-limit.)
 #
 # Routine non-security upgrades are handled out-of-band (manually or by
 # a separate workflow); this file's role is to keep the security pipe
 # unblocked without flooding the repo with churn.
+#
+# Repo-level prerequisites (Settings > Code security):
+#   - Dependency graph: enabled
+#   - Dependabot alerts: enabled
+#   - Dependabot security updates: enabled
+#   - Grouped security updates: enabled
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -22,8 +30,12 @@ updates:
     open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    # Security updates still get grouped (minor/patch only). Major
-    # security bumps fall through ungrouped for breaking-change review.
+    # Group SemVer minor/patch security alerts so multiple simultaneous
+    # advisories in this ecosystem bundle into a single PR. SemVer-major
+    # security bumps fall through to Dependabot's normal ungrouped
+    # behavior so they can be reviewed individually for breaking changes
+    # (independent of advisory severity — this is purely a SemVer-level
+    # filter).
     groups:
       nuget-security:
         applies-to: security-updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,37 +1,30 @@
 # Dependabot configuration for microsoft/typechat.net.
 #
-# Per ecosystem: routine minor/patch updates are grouped into a single
-# weekly PR; security updates ship as their own grouped PR; major-version
-# bumps fall through ungrouped (one PR per package) for breaking-change
-# review.
+# Security-only mode: we want Dependabot alerts (security updates) to flow,
+# but NOT routine weekly version-update PRs. Setting
+# open-pull-requests-limit: 0 on each ecosystem block disables version
+# updates while keeping the ecosystem registered so security-update PRs
+# can still be opened automatically when an alert fires.
+#
+# Routine non-security upgrades are handled out-of-band (manually or by
+# a separate workflow); this file's role is to keep the security pipe
+# unblocked without flooding the repo with churn.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
 version: 2
 updates:
-  # Maintain dependencies for nuget
   - package-ecosystem: "nuget"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
-    ignore:
-      # For all System.* and Microsoft.Extensions/Bcl.* packages, ignore all major version updates
-      - dependency-name: "System.*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "Microsoft.Extensions.*"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "Microsoft.Bcl.*"
-        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    # Group routine minor/patch bumps to keep PR volume manageable.
-    # Security updates are grouped separately so they can be prioritised,
-    # and major-version bumps fall through to one-PR-per-package.
+    # Security updates still get grouped (minor/patch only). Major
+    # security bumps fall through ungrouped for breaking-change review.
     groups:
-      nuget-minor-patch:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
       nuget-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -42,15 +35,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    # Same policy as nuget above: group minor/patch only so major-version
-    # action bumps (e.g. actions/checkout v4 -> v5) get individual PRs
-    # and can be reviewed for breaking-change notes.
     groups:
-      github-actions:
-        patterns: ["*"]
-        update-types: ["minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,14 @@
 # Dependabot configuration for microsoft/typechat.net.
 #
-# Single-PR-per-ecosystem mode: every routine version bump (major, minor,
-# patch) is bundled into ONE grouped PR per ecosystem per weekly run.
-# Security updates ship as their own grouped PR so they aren't buried
-# under routine churn.
+# Security-only mode: we want Dependabot alerts (security updates) to flow,
+# but NOT routine weekly version-update PRs. Setting
+# open-pull-requests-limit: 0 on each ecosystem block disables version
+# updates while keeping the ecosystem registered so security-update PRs
+# can still be opened automatically when an alert fires.
 #
-# Tradeoff: one large PR is easier to review at a glance than many small
-# ones, but if it fails CI the cause is harder to bisect because the
-# compounded breaking changes (e.g. dotenv 16->17 + sqlite3 5->6) all
-# land at once. If a routine PR keeps failing, drop the offending
-# package(s) from the PR's commit list and let it land without them.
+# Routine non-security upgrades are handled out-of-band (manually or by
+# a separate workflow); this file's role is to keep the security pipe
+# unblocked without flooding the repo with churn.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -20,15 +19,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
+    # Security updates still get grouped (minor/patch only). Major
+    # security bumps fall through ungrouped for breaking-change review.
     groups:
-      # Routine updates: every package, every update-type, one PR.
-      nuget-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
-      # Security alerts: separate PR so they can be prioritised. Major
-      # security bumps fall through ungrouped for breaking-change review.
       nuget-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -39,12 +35,10 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
-      github-actions-all:
-        patterns: ["*"]
-        update-types: ["major", "minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,15 @@
 # Dependabot configuration for microsoft/typechat.net.
 #
-# Security-only mode: we want Dependabot alerts (security updates) to flow,
-# but NOT routine weekly version-update PRs. Setting
-# open-pull-requests-limit: 0 on each ecosystem block disables version
-# updates while keeping the ecosystem registered so security-update PRs
-# can still be opened automatically when an alert fires.
+# Single-PR-per-ecosystem mode: every routine version bump (major, minor,
+# patch) is bundled into ONE grouped PR per ecosystem per weekly run.
+# Security updates ship as their own grouped PR so they aren't buried
+# under routine churn.
 #
-# Routine non-security upgrades are handled out-of-band (manually or by
-# a separate workflow); this file's role is to keep the security pipe
-# unblocked without flooding the repo with churn.
+# Tradeoff: one large PR is easier to review at a glance than many small
+# ones, but if it fails CI the cause is harder to bisect because the
+# compounded breaking changes (e.g. dotenv 16->17 + sqlite3 5->6) all
+# land at once. If a routine PR keeps failing, drop the offending
+# package(s) from the PR's commit list and let it land without them.
 #
 # Docs: https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
@@ -19,12 +20,15 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 0
     labels:
       - "dependencies"
-    # Security updates still get grouped (minor/patch only). Major
-    # security bumps fall through ungrouped for breaking-change review.
     groups:
+      # Routine updates: every package, every update-type, one PR.
+      nuget-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
+      # Security alerts: separate PR so they can be prioritised. Major
+      # security bumps fall through ungrouped for breaking-change review.
       nuget-security:
         applies-to: security-updates
         patterns: ["*"]
@@ -35,10 +39,12 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     groups:
+      github-actions-all:
+        patterns: ["*"]
+        update-types: ["major", "minor", "patch"]
       github-actions-security:
         applies-to: security-updates
         patterns: ["*"]


### PR DESCRIPTION
## Why

Last week's first scheduled Dependabot run produced 5 PRs (#322 #323 #324 #325 #326): one grouped minor/patch bump plus 4 ungrouped majors. We want **zero routine version-update PRs** — only security-update PRs.

## What this does

Sets `open-pull-requests-limit: 0` on each ecosystem block. Per [GitHub docs](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit) this disables routine version-update PRs while keeping the ecosystem registered so security-update PRs still flow when alerts fire. The `applies-to: security-updates` grouping rules are preserved so security PRs still consolidate.

## Followup

The 4 noisy major PRs (#322 #323 #324 #325 #326) and 2 stale Jan PRs (#314 #317) were already closed. Future routine bumps will need to be made manually (or via a separate workflow); only security alerts will auto-PR.
